### PR TITLE
Making the code run commands instead of return 0

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ def receive():
             print("Error receiving: " + str(e))
             break
 
-if __name__ == "main":
+if __name__ == "__main__":
 
     # Create and start a listening thread that runs in the background
     # This utilizes our receive functions and will continuously monitor for incoming messages


### PR DESCRIPTION
Instead of having __name__ == "__main__", the template code had __name__ == "main"

From here on, I would recommend either 
1) informing teams of this bug fix OR
2) waving the penalty for teams who may have changed the code below the "DO NOT CHANGE" line so teams are not penalized for making their code work

Preferably both since some teams might be stressed as to why their code is not functioning the way it should be, as I know we were for quite some time.

In case the reason for the change is not clear, here is an explanation:
The __name__ == "__main__" acts as an execution statement for if the file is NOT being called from another file. Usually, when the file is run directly, the __name__ variable is "__main__" instead of "main", so the string boolean comparison is incorrect and would never actually run, leaving python to do nothing and return 0

I hope this helps